### PR TITLE
Release version 1.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,7 +236,7 @@ dependencies = [
 
 [[package]]
 name = "git-gr"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "calm_io",
  "camino",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-gr"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 authors = ["Rebecca Turner <rbt@sent.as>"]
 description = "A Gerrit CLI"


### PR DESCRIPTION
Update version to 1.0.2 with [cargo-release](https://github.com/crate-ci/cargo-release).
Merge this PR to build and publish a new release.