### PR TITLE
Release version 1.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "git-gr"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "calm_io",
  "camino",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-gr"
-version = "1.0.2"
+version = "1.0.3"
 edition = "2021"
 authors = ["Rebecca Turner <rbt@sent.as>"]
 description = "A Gerrit CLI"


### PR DESCRIPTION
Update version to 1.0.3 with [cargo-release](https://github.com/crate-ci/cargo-release).
Merge this PR to build and publish a new release.