### PR TITLE
Query related changes when traversing chains and add `show-chain` command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -91,6 +91,13 @@ pub enum Command {
         method: Method,
         endpoint: String,
     },
+    /// Display a chain of related changes.
+    ShowChain {
+        /// A query for the change to show.
+        ///
+        /// Defaults to the `HEAD` commit's change.
+        query: Option<String>,
+    },
 }
 
 #[derive(Debug, Clone, Subcommand)]

--- a/src/commit_hash.rs
+++ b/src/commit_hash.rs
@@ -1,20 +1,25 @@
 use std::fmt::Display;
 use std::ops::Deref;
 
-/// A Gerrit change ID.
-///
-/// This is a string starting with `I` and followed by 40 hex characters.
+/// A Git commit hash.
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(transparent)]
-pub struct ChangeId(pub String);
+pub struct CommitHash(pub String);
 
-impl Display for ChangeId {
+impl CommitHash {
+    /// Get an abbreviated 8-character Git hash.
+    pub fn abbrev(&self) -> &str {
+        &self.0[..8]
+    }
+}
+
+impl Display for CommitHash {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.0.fmt(f)
     }
 }
 
-impl Deref for ChangeId {
+impl Deref for CommitHash {
     type Target = str;
 
     fn deref(&self) -> &Self::Target {

--- a/src/commit_info.rs
+++ b/src/commit_info.rs
@@ -1,0 +1,20 @@
+use crate::git_person_info::GitPersonInfo;
+
+#[derive(serde::Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
+pub struct CommitInfo {
+    commit: Option<String>,
+    parents: Vec<CommitInfoMinimal>,
+    author: GitPersonInfo,
+    subject: String,
+    message: Option<String>,
+}
+
+#[derive(serde::Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
+pub struct CommitInfoMinimal {
+    commit: String,
+    subject: Option<String>,
+}

--- a/src/dependency_graph_builder.rs
+++ b/src/dependency_graph_builder.rs
@@ -1,0 +1,151 @@
+use std::collections::btree_map::Entry;
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::collections::VecDeque;
+
+use miette::Context;
+
+use crate::change_number::ChangeNumber;
+use crate::dependency_graph::DependencyGraph;
+use crate::dependency_graph::DependsOnRelation;
+use crate::gerrit::Gerrit;
+use crate::query_result::ChangeDependencies;
+use crate::related_changes_info::RelatedChangesInfo;
+
+pub struct DependencyGraphBuilder<'a> {
+    inner: DependencyGraph,
+
+    gerrit: &'a mut Gerrit,
+    dependencies: BTreeMap<ChangeNumber, ChangeDependencies>,
+    related: BTreeMap<ChangeNumber, RelatedChangesInfo>,
+}
+
+impl<'a> DependencyGraphBuilder<'a> {
+    pub fn new(gerrit: &'a mut Gerrit, root: ChangeNumber) -> Self {
+        Self {
+            inner: DependencyGraph::new(root),
+            gerrit,
+            dependencies: Default::default(),
+            related: Default::default(),
+        }
+    }
+
+    pub fn build(self) -> DependencyGraph {
+        self.inner
+    }
+
+    fn dependencies(&mut self, change: ChangeNumber) -> miette::Result<&ChangeDependencies> {
+        match self.dependencies.entry(change) {
+            Entry::Vacant(entry) => Ok(entry.insert(
+                self.gerrit
+                    .dependencies(change)
+                    .wrap_err("Failed to get change dependencies")?
+                    .filter_unmerged(self.gerrit)?,
+            )),
+            Entry::Occupied(entry) => Ok(entry.into_mut()),
+        }
+    }
+
+    fn related(&mut self, change: ChangeNumber) -> miette::Result<&RelatedChangesInfo> {
+        match self.related.entry(change) {
+            Entry::Vacant(entry) => Ok(entry.insert(
+                self.gerrit
+                    .related_changes(change, None)
+                    .wrap_err("Failed to get related changes")?,
+            )),
+            Entry::Occupied(entry) => Ok(entry.into_mut()),
+        }
+    }
+
+    fn indirect_reverse_dependencies(
+        &mut self,
+        change: ChangeNumber,
+    ) -> miette::Result<BTreeSet<ChangeNumber>> {
+        // If a change B depends on a change A, and A has a commit that B doesn't, in the web UI
+        // you see this. On the page for A:
+        //
+        //     Relation chain
+        //        B (Indirect relation)
+        //     -> A
+        //
+        // On the page for B:
+        //
+        //     Relation chain:
+        //     -> B
+        //        A (Not current)
+        //
+        // In the API, you get this.
+        // `git gr cli -- query A --dependencies`
+        //     (nothing)
+        //
+        // `git gr api -- "/changes/PROJECT~A/revisions/current/related"`
+        //     (A, B)
+        //
+        // `git gr cli -- query B --dependencies`
+        //     dependsOn: A
+        //
+        // `git gr api -- "/changes/PROJECT~B/revisions/current/related"`
+        //     (A, B)
+        //
+        // Note that `--dependencies` returns valid data for _child_ dependencies, even if they're
+        // out of date...?
+        //
+        // Therefore, we can list out-of-date dependencies with the following logic:
+        //
+        //     if related(A) includes B
+        //     and B depends on A
+        //     then B is out of date with A
+        let related_changes = self.related(change)?.change_numbers();
+
+        let mut indirect = BTreeSet::new();
+        for related in related_changes {
+            if self
+                .dependencies(related)?
+                .depends_on_numbers()
+                .contains(&change)
+            {
+                indirect.insert(related);
+            }
+        }
+        Ok(indirect)
+    }
+
+    pub fn traverse(gerrit: &'a mut Gerrit, root: ChangeNumber) -> miette::Result<Self> {
+        let mut builder = Self::new(gerrit, root);
+        let mut seen = BTreeSet::new();
+        seen.insert(root);
+        let mut queue = VecDeque::new();
+        queue.push_front(root);
+
+        while let Some(change) = queue.pop_back() {
+            let needed_by_indirect_numbers = builder.indirect_reverse_dependencies(change)?;
+            let dependencies = builder.dependencies(change)?;
+            let depends_on_numbers = dependencies.depends_on_numbers();
+            let needed_by_numbers = dependencies.needed_by_numbers();
+            let needed_by_numbers = needed_by_numbers.union(&needed_by_indirect_numbers);
+
+            tracing::debug!(?dependencies, "Found change dependencies");
+            for depends_on in depends_on_numbers {
+                builder
+                    .inner
+                    .insert(DependsOnRelation { change, depends_on })?;
+                if !seen.contains(&depends_on) {
+                    seen.insert(depends_on);
+                    queue.push_front(depends_on);
+                }
+            }
+            for needed_by in needed_by_numbers {
+                builder.inner.insert(DependsOnRelation {
+                    change: *needed_by,
+                    depends_on: change,
+                })?;
+                if !seen.contains(needed_by) {
+                    seen.insert(*needed_by);
+                    queue.push_front(*needed_by);
+                }
+            }
+        }
+
+        Ok(builder)
+    }
+}

--- a/src/git.rs
+++ b/src/git.rs
@@ -9,6 +9,7 @@ use miette::IntoDiagnostic;
 use regex::Regex;
 
 use crate::change_id::ChangeId;
+use crate::commit_hash::CommitHash;
 use crate::format_bulleted_list;
 use crate::gerrit::GerritGitRemote;
 
@@ -246,12 +247,8 @@ impl Git {
     }
 
     /// Get the `HEAD` commit hash.
-    pub fn get_head(&self) -> miette::Result<String> {
-        self.command()
-            .args(["rev-parse", "HEAD"])
-            .output_checked_utf8()
-            .into_diagnostic()
-            .map(|output| output.stdout.trim().to_owned())
+    pub fn get_head(&self) -> miette::Result<CommitHash> {
+        self.rev_parse("HEAD")
     }
 
     /// Get the `.git` directory path.
@@ -263,14 +260,15 @@ impl Git {
             .map(|output| Utf8PathBuf::from(output.stdout.trim()))
     }
 
-    pub fn rev_parse(&self, commitish: &str) -> miette::Result<String> {
-        Ok(self
-            .command()
-            .args(["rev-parse", commitish])
-            .output_checked_utf8()
-            .into_diagnostic()?
-            .stdout
-            .trim()
-            .to_owned())
+    pub fn rev_parse(&self, commitish: &str) -> miette::Result<CommitHash> {
+        Ok(CommitHash(
+            self.command()
+                .args(["rev-parse", commitish])
+                .output_checked_utf8()
+                .into_diagnostic()?
+                .stdout
+                .trim()
+                .to_owned(),
+        ))
     }
 }

--- a/src/git_person_info.rs
+++ b/src/git_person_info.rs
@@ -1,0 +1,9 @@
+#[derive(serde::Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
+pub struct GitPersonInfo {
+    pub name: String,
+    pub email: String,
+    date: String,
+    tz: i16,
+}

--- a/src/related_change_and_commit_info.rs
+++ b/src/related_change_and_commit_info.rs
@@ -1,0 +1,21 @@
+use crate::change_id::ChangeId;
+use crate::change_number::ChangeNumber;
+use crate::change_status::ChangeStatus;
+use crate::commit_info::CommitInfo;
+
+#[derive(serde::Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
+pub struct RelatedChangeAndCommitInfo {
+    pub project: String,
+    pub change_id: Option<ChangeId>,
+    pub commit: CommitInfo,
+    #[serde(rename = "_change_number")]
+    pub change_number: Option<ChangeNumber>,
+    #[serde(rename = "_revision_number")]
+    pub revision_number: Option<u32>,
+    #[serde(rename = "_current_revision_number")]
+    pub current_revision_number: Option<u32>,
+    pub status: Option<ChangeStatus>,
+    pub submittable: bool,
+}

--- a/src/related_changes_info.rs
+++ b/src/related_changes_info.rs
@@ -1,0 +1,19 @@
+use std::collections::BTreeSet;
+
+use crate::change_number::ChangeNumber;
+use crate::related_change_and_commit_info::RelatedChangeAndCommitInfo;
+
+#[derive(serde::Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct RelatedChangesInfo {
+    pub changes: Vec<RelatedChangeAndCommitInfo>,
+}
+
+impl RelatedChangesInfo {
+    pub fn change_numbers(&self) -> BTreeSet<ChangeNumber> {
+        self.changes
+            .iter()
+            .flat_map(|change| change.change_number)
+            .collect()
+    }
+}


### PR DESCRIPTION
This allows you to restack partially-out-of-date changes.

Closes #23
Closes #24 