### PR TITLE
Don't fill terminal width with tables

### DIFF
--- a/src/gerrit.rs
+++ b/src/gerrit.rs
@@ -398,7 +398,7 @@ impl Gerrit {
         let mut table = comfy_table::Table::new();
         table
             .load_preset(comfy_table::presets::NOTHING)
-            .set_content_arrangement(comfy_table::ContentArrangement::DynamicFullWidth)
+            .set_content_arrangement(comfy_table::ContentArrangement::Dynamic)
             .set_header(
                 [
                     "#", "Subject",


### PR DESCRIPTION
In `gerrit query`, don't fill the full terminal width with padding, it makes tables look weird.