### PR TITLE
Fix query serde error

### DIFF
--- a/src/submit_records.rs
+++ b/src/submit_records.rs
@@ -7,5 +7,6 @@ use crate::submit_status::SubmitStatus;
 #[allow(dead_code)]
 pub struct SubmitRecord {
     pub status: SubmitStatus,
+    #[serde(default)]
     labels: Vec<SubmitLabel>,
 }


### PR DESCRIPTION
The `labels` field isn't present if there's no labels.

Fixes a bug @RaitoBezarius saw