### PR TITLE
Release version 1.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,7 +651,7 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "git-gr"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "cached",
  "calm_io",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-gr"
-version = "1.3.0"
+version = "1.4.0"
 edition = "2021"
 authors = ["Rebecca Turner <rbt@sent.as>"]
 description = "A Gerrit CLI"


### PR DESCRIPTION
Update version to 1.4.0 with [cargo-release](https://github.com/crate-ci/cargo-release).
Merge this PR to build and publish a new release.