### PR TITLE
Release version 1.4.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -658,7 +658,7 @@ checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "git-gr"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "cached",
  "calm_io",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-gr"
-version = "1.4.2"
+version = "1.4.3"
 edition = "2021"
 authors = ["Rebecca Turner <rbt@sent.as>"]
 description = "A Gerrit CLI"


### PR DESCRIPTION
Update version to 1.4.3 with [cargo-release](https://github.com/crate-ci/cargo-release).
Merge this PR to build and publish a new release.